### PR TITLE
fix: add spotify namespace

### DIFF
--- a/src/serialize-feed.ts
+++ b/src/serialize-feed.ts
@@ -164,6 +164,8 @@ export function generateRssFeed(feed: SesamyFeed): string {
         '@_enabled': (!!feed.spotify.sandbox).toString(),
       },
     };
+
+    rss['@_xmlns:spotify'] = 'http://www.spotify.com/ns/rss';
   }
 
   const options = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including the Spotify XML namespace in RSS feeds when Spotify-specific data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->