### PR TITLE
fix: external ids to be parsed as array

### DIFF
--- a/src/feed-parser.ts
+++ b/src/feed-parser.ts
@@ -10,6 +10,7 @@ export async function parseFeedToJson(text: string): Promise<RssFeed> {
     'sesamy:sesamy-item',
     'sesamy:product',
     'sesamy:selling-point',
+    'sesamy:external-id',
     'sesamy:price-override',
     'enclosure',
     'omny:clipCustomField',

--- a/test/fixtures/kjente.rss
+++ b/test/fixtures/kjente.rss
@@ -33,7 +33,8 @@
     <itunes:explicit>no</itunes:explicit>
     <sesamy:title>Markus Test</sesamy:title>
     <sesamy:private>false</sesamy:private>
-    <sesamy:vendor-id>demo</sesamy:vendor-id>
+    <sesamy:vendor-id>demo</sesamy:vendor-id>    
+    <sesamy:external-id id="spotifyId" value="6bWn1aLxsl"/>    
     <sesamy:product>
       <id>rss_1K-03nMwHqboV2DsVuhwn</id>
       <sesamy:price>5</sesamy:price>

--- a/test/sesamy-parser.spec.ts
+++ b/test/sesamy-parser.spec.ts
@@ -7,7 +7,6 @@ global.structuredClone = obj => JSON.parse(JSON.stringify(obj));
 
 const fredagspodden = fs.readFileSync('./test/fixtures/fredagspodden.rss');
 const spar = fs.readFileSync('./test/fixtures/spar.rss');
-const acast = fs.readFileSync('./test/fixtures/acast.rss');
 const kjente = fs.readFileSync('./test/fixtures/kjente.rss');
 const fof = fs.readFileSync('./test/fixtures/fof.rss');
 const omny = fs.readFileSync('./test/fixtures/omny.rss');
@@ -135,7 +134,9 @@ describe('Sesamy parser service tests', () => {
     expect(sesamyFeed).toMatchObject({
       title: 'Markus Test',
       titleWithUsername: 'Markus Test',
-      externalIds: {},
+      externalIds: {
+        spotifyId: '6bWn1aLxsl',
+      },
       subtitle:
         'Kjente Norske ordtak i en tolkning av Even C. Jystad.Buy at https://sesamy.com/podcasts/sid:oPWrf4FIdFVRpS0chQ5Nj',
       description:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved feed parsing to support extraction of external IDs from RSS feeds.
* **Tests**
  * Updated test cases and fixtures to validate the correct handling and extraction of external IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->