### PR TITLE
fix: render itunes type

### DIFF
--- a/src/serialize-feed.ts
+++ b/src/serialize-feed.ts
@@ -114,6 +114,7 @@ export function generateRssFeed(feed: SesamyFeed): string {
         'itunes:email': feed.owner?.email || 'feed@sesamy.com',
       },
       'itunes:explicit': boolToString(feed.isExplicit),
+      'itunes:type': feed.podcastType?.toLowerCase() || 'episodic',
       'sesamy:title': feed.title,
       'sesamy:private': feed.sesamy.isPrivate.toString(),
       'sesamy:vendor-id': feed.sesamy.vendorId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSS feeds now include iTunes podcast type metadata. The feed uses the specified podcast type when available, otherwise defaults to episodic format to improve podcast distribution and discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->